### PR TITLE
Allow to skip service restart notifications

### DIFF
--- a/providers/conf.rb
+++ b/providers/conf.rb
@@ -51,7 +51,9 @@ action :create do
       :mode => new_resource.mode,
       :withs => withs
     )
-    notifies :restart, "service[monit]", new_resource.reload
+    if new_resource.reload
+      notifies :restart, "service[monit]", new_resource.reload 
+    end
   end
 end
 
@@ -63,6 +65,8 @@ action :delete do
     action :delete
     source new_resource.template
     cookbook new_resource.cookbook
-    notifies :restart, "service[monit]", new_resource.reload
+    if new_resource.reload
+      notifies :restart, "service[monit]", new_resource.reload
+    end
   end
 end


### PR DESCRIPTION
This would allow to put the notification on monit_conf resource to have
only one restart during a chef-run (instead of once per monit_conf)

Change-Id: I61b3dacd81f6801e62e841311d9ada5d58850a28