### PR TITLE
Write on the correct config file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default[:monit][:config_file] = '/etc/monit/monitrc'
+default[:monit][:config_file] = '/etc/monitrc'
 
 default[:monit][:email_alerts?]  = true
 default[:monit][:notify_email]   = 'root@localhost'


### PR DESCRIPTION
The systemd startup script doesn't try to look
at the right place, and that would be hard to really fix.

```
[Unit]
Description=Pro-active monitoring utility for unix systems
After=network.target

[Service]
Type=simple
ExecStart=/usr/bin/monit -I
ExecStop=/usr/bin/monit quit
ExecReload=/usr/bin/monit reload

[Install]
WantedBy=multi-user.target
```